### PR TITLE
fix (from date): use formats with seconds granularity

### DIFF
--- a/harvester-oaipmh.py
+++ b/harvester-oaipmh.py
@@ -215,9 +215,10 @@ def main():
         # harvesting
         with Scythe(harvest_url, timeout=180, max_retries=3, default_retry_after=60) as client:
             if from_date:
-                print(f"Incremental harvest since {from_date}")
+                from_date_secs = datetime.strptime(from_date, '%Y-%m-%dT%H:%M:%S.%f%z').strftime('%Y-%m-%dT%H:%M:%SZ')
+                print(f"Incremental harvest since {from_date_secs}")
                 records = client.list_records(
-                    from_=from_date,
+                    from_=from_date_secs,
                     metadata_prefix=metadata_prefix,
                     set_=set
                 )


### PR DESCRIPTION
This PR formats the from_date obtained for the warehouse API to seconds granularity as expected by OAI-PMH.

Example:
- DB sets from_date `2025-11-12 09:14:23.958454+00` for a new harvest run
- API gets this from DB using the psycopg client: `'from_date': datetime.datetime(2025, 11, 12, 9, 14, 23, 958454, tzinfo=datetime.timezone.utc)`
- FAST API the returns this as "2025-11-12T09:14:23.958454Z"

The harvester now formats this to "%Y-%m-%dT%H:%M:%SZ" (2025-11-12T09:14:23) before sending this to the OAI-PMH endpoint.

Another approach would be make the warehouse API return seconds only: `date.replace(microsecond=0)`. This seems like a clean approach. Or maybe there is even a way to tell Postgres to use seconds granularity.