### PR TITLE
Build and publish docker image for ARM64

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,9 +1,10 @@
 name: Build and publish Docker image
 
 on:
+  workflow_dispatch:
   push:
-    branches:
-      - master
+    branches: [ master ]
+    tags: [ "v*.*.*" ]
 
 jobs:
   build-and-push:
@@ -15,7 +16,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -27,9 +28,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/eosc-data-commons/metadata-crawlers
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        id: build
+        uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64, linux/arm64
           push: true
-          tags: ghcr.io/eosc-data-commons/metadata-crawlers:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Currently the docker image cannot be deployed on ARM64 architectures (e.g. macbook), this PR improve the github action workflow to:

- [x] Build for amd64 (regular server) and arm64
- [x] Handle publishing a specific version (e.g. `0.1.2`) when a git tag is created and pushed. This way when we create a tag on the git repository, a versioned docker image will be published for this version
- [x] Enable to manually trigger the workflow from the github action UI