### PR TITLE
Add retry strategy

### DIFF
--- a/harvester/harvester_oaipmh.py
+++ b/harvester/harvester_oaipmh.py
@@ -229,3 +229,6 @@ def run_harvester_oaipmh(run_info: dict) -> bool:
             failed_events
         )
         return False
+    
+    finally:
+        close_dataverse_client()

--- a/harvester/harvester_oaipmh.py
+++ b/harvester/harvester_oaipmh.py
@@ -16,6 +16,12 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 # shared http client for Dataverse requests
 _DATAVERSE_CLIENT = httpx.Client(timeout=30)
 
+scythe_retry_strategy = {
+    "max_retries": 3,
+    "retry_status_codes": [500, 502, 503, 504],
+    "default_retry_after": 10,
+    "timeout": 120,
+}
 
 def close_dataverse_client():
     try:

--- a/harvester/harvester_oaipmh.py
+++ b/harvester/harvester_oaipmh.py
@@ -120,6 +120,8 @@ def run_harvester_oaipmh(run_info: dict) -> bool:
         harvest_params = config.get("harvest_params")
         metadata_prefix = harvest_params.get("metadata_prefix", "oai_dc")
         set_ = harvest_params.get("set")
+        retry_strategy = harvest_params.get("retry_strategy", {})
+        retry_config = {**scythe_retry_strategy, **retry_strategy}  # merge with defaults
         code = config.get("code")
         additional = harvest_params.get("additional_metadata_params")
         additional_protocol = additional.get("protocol") if additional else None
@@ -131,7 +133,7 @@ def run_harvester_oaipmh(run_info: dict) -> bool:
             transform = ET.XSLT(xslt_doc)
 
         # harvesting
-        with Scythe(harvest_url, timeout=180, max_retries=3, default_retry_after=60) as client:
+        with Scythe(harvest_url, **retry_config) as client:
             if from_:
                 logger.info("Incremental harvest since %s", from_date)
                 records = client.list_records(

--- a/harvester/main.py
+++ b/harvester/main.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 from datetime import datetime, timezone
 
-from .harvester_oaipmh import run_harvester_oaipmh, close_dataverse_client
+from .harvester_oaipmh import run_harvester_oaipmh
 from harvester.harvester_finbif import run_harvester_finbif
 from .db_api_functions import start_harvest_run, close_harvest_run, get_open_run_id, close_warehouse_client
 from .logging import setup_logging
@@ -80,7 +80,7 @@ def main():
                 "completed_at": end_time,
             }
             close_harvest_run(close_harvest_run_payload)
-        close_dataverse_client()
         close_warehouse_client()
+        
 
     return 0 if harvest_success else 1


### PR DESCRIPTION
Adding an option to define a custom retry strategy for each OAI-PMH endpoint (or any future harvesting method).
Expects retry_strategy as an optional dict element of harvest_params:
```
harvest_params = {
    metadata_prefix: str
    set: Optional[list[str]]
    additional_metadata_params: Optional[AdditionalMetadataParams]

    retry_strategy: Optional[{
        max_retries: Optional[int]
        retry_status_codes: Optional[list[int]]
        default_retry_after: Optional[int | float]
        timeout: Optional[int | float]
    }]
}
```
These are the attribute names that Scythe client expects, so they should not be changed.