### PR TITLE
Make MDposit API harvester

### DIFF
--- a/harvester/harvester_mdposit.py
+++ b/harvester/harvester_mdposit.py
@@ -1,0 +1,256 @@
+import logging, os, requests, xml.etree.ElementTree as ET, time, mimetypes
+from .db_api_functions import send_harvest_event
+from xml.dom import minidom
+
+logger = logging.getLogger(__name__)
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+
+def guess_format(filename: str) -> str:
+    mime, _ = mimetypes.guess_type(filename)
+
+    # fallback for unknown scientific formats
+    if mime is None:
+        ext = filename.lower().split(".")[-1]
+        custom_map = {
+            "pdb": "chemical/x-pdb",
+            "prmtop": "application/octet-stream",
+            "xtc": "application/octet-stream",
+            "bin": "application/octet-stream",
+            "topology": "application/octet-stream",
+        }
+        return custom_map.get(ext, "application/octet-stream")
+    return mime
+
+
+
+def fetch_projects_summary() -> dict:
+    url = "https://mdposit.mddbr.eu/api/rest/v1/projects/summary"
+    headers = {"Accept": "application/json"}
+    response = requests.get(url, headers = headers, timeout = 30)
+    response.raise_for_status()
+    return response.json()
+
+
+
+def fetch_projects_data(base_api_url: str) -> list:
+    """
+    Fetch all projects from the MDposit API using pagination.
+    """
+    project_summary = fetch_projects_summary()
+    total = project_summary["projectsCount"]
+    print(f"Total projects: {total}")
+
+    all_projects = []
+    headers = {"Accept": "application/json"}
+    page = 1
+
+    while len(all_projects) < total:
+        response = requests.get(
+            f"{base_api_url}/projects",
+            headers = headers,
+            params = {"limit": 100, "page": page},
+            timeout = 30
+        )
+        response.raise_for_status()
+        data = response.json()
+        all_projects.extend(data["projects"])
+        print(f"Fetched page {page}, total so far: {len(all_projects)}")
+        page += 1
+        time.sleep(1)
+
+    return all_projects
+
+
+
+def mdposit_data_to_datacite(project: dict):
+    meta = project["metadata"]
+
+    # NAMESPACES
+    ET.register_namespace("", "http://www.openarchives.org/OAI/2.0/")
+    ET.register_namespace("xsi", "http://www.w3.org/2001/XMLSchema-instance")
+    ET.register_namespace("dc", "http://datacite.org/schema/kernel-4")
+
+    # DATES
+    creation_date = project.get("creationDate", "")
+    update_date = project.get("updateDate", "")
+
+    # OAI-PMH RECORD ROOT
+    record = ET.Element(
+        "record",
+        {
+            "xmlns": "http://www.openarchives.org/OAI/2.0/",
+            "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+        },
+    )
+
+    # HEADER
+    header = ET.SubElement(record, "header")
+
+    header_identifier = ET.SubElement(header, "identifier")
+    header_identifier.text = project['accession']
+
+    datestamp = ET.SubElement(header, "datestamp")
+    datestamp.text = update_date[:10] if update_date else creation_date[:10]
+
+    # METADATA BLOCK
+    metadata = ET.SubElement(record, "metadata")
+
+    # DATACITE RESOURCE
+    resource = ET.SubElement(
+        metadata,
+        "resource",
+        {
+            "xmlns": "http://datacite.org/schema/kernel-4",
+            "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+            "xsi:schemaLocation": (
+                "http://datacite.org/schema/kernel-4 "
+                "https://schema.datacite.org/meta/kernel-4.6/metadata.xsd"
+            ),
+        },
+    )
+
+    # IDENTIFIER
+    identifier = ET.SubElement(resource, "identifier", identifierType = "URL")
+    identifier.text = f"https://mdposit.mddbr.eu/#/browse/{project['accession']}"
+
+    # CREATORS
+    creators = ET.SubElement(resource, "creators")
+    for author in meta.get("AUTHORS") or []:
+        creator = ET.SubElement(creators, "creator")
+        creator_name = ET.SubElement(creator, "creatorName", nameType = "Personal")
+        creator_name.text = author
+
+    # TITLES
+    titles = ET.SubElement(resource, "titles")
+    ET.SubElement(titles, "title").text = meta.get("NAME", "")
+
+    # PUBLISHER
+    ET.SubElement(resource, "publisher").text = "MDposit"
+
+    # PUBLICATION YEAR
+    ET.SubElement(resource, "publicationYear").text = creation_date[:4]
+
+    # RESOURCE TYPE
+    ET.SubElement(resource, "resourceType", resourceTypeGeneral="Dataset").text = "Molecular Dynamics Trajectory"
+
+    # SUBJECTS
+    subjects = ET.SubElement(resource, "subjects")
+    for key in meta.get("SYSKEYS") or []:
+        ET.SubElement(subjects, "subject").text = key
+
+    for domain in meta.get("DOMAINS") or []:
+        ET.SubElement(subjects, "subject").text = domain
+
+    if meta.get("METHOD"):
+        ET.SubElement(subjects, "subject").text = meta.get("METHOD")
+
+    # CONTRIBUTORS
+    if meta.get("CONTACT"):
+        contributors = ET.SubElement(resource, "contributors")
+        contributor = ET.SubElement(contributors, "contributor", contributorType = "ContactPerson")
+        ET.SubElement(contributor, "contributorName").text = meta["CONTACT"]
+
+    # DATES
+    dates = ET.SubElement(resource, "dates")
+    if creation_date:
+        ET.SubElement(dates, "date", dateType="Created").text = creation_date[:10]
+
+    if update_date:
+        ET.SubElement(dates, "date", dateType="Updated").text = update_date[:10]
+
+    # RELATED IDENTIFIERS
+    related = ET.SubElement(resource, "relatedIdentifiers")
+    # PDB IDs
+    for pdbid in meta.get("PDBIDS") or []:
+        ET.SubElement(related, "relatedIdentifier", relatedIdentifierType = "URL", relationType = "IsDerivedFrom").text = f"https://www.rcsb.org/structure/{pdbid}"
+
+    # UniProt references
+    for ref in meta.get("REFERENCES") or []:
+        ET.SubElement(related, "relatedIdentifier", relatedIdentifierType = "URL", relationType = "References").text = f"https://www.uniprot.org/uniprot/{ref}"
+
+    # DOI from citation
+    citation = meta.get("CITATION") or ""
+    if citation:
+        if "https://doi.org/" in citation:
+            doi = citation.split("https://doi.org/")[-1].strip()
+            ET.SubElement(related, "relatedIdentifier", relatedIdentifierType="DOI", relationType="IsDocumentedBy").text = doi
+        elif "DOI:" in citation:
+            doi = citation.replace("DOI:", "").strip()
+            ET.SubElement(related, "relatedIdentifier", relatedIdentifierType="DOI", relationType="IsDocumentedBy").text = doi
+
+    # FORMATS
+    files = project.get("files") or []
+    formats_set = {guess_format(f) for f in files if "." in f}
+    formats_el = ET.SubElement(resource, "formats")
+    for fmt in sorted(formats_set):
+        ET.SubElement(formats_el, "format").text = fmt
+
+    # RIGHTS
+    rights_list = ET.SubElement(resource, "rightsList")
+    if meta.get("LINKCENSE") and meta.get("LICENSE"):
+        ET.SubElement(rights_list, "rights", rightsURI = meta.get("LINKCENSE"), rightsIdentifier = "CC-BY-4.0").text = meta.get("LICENSE")
+
+    # DESCRIPTIONS
+    descriptions = ET.SubElement(resource, "descriptions")
+    if meta.get("DESCRIPTION"):
+        ET.SubElement(descriptions, "description", descriptionType = "Abstract").text = meta["DESCRIPTION"]
+
+    xml_str = ET.tostring(record, encoding="unicode")
+    xml_pretty = minidom.parseString(xml_str).toprettyxml(indent="  ")
+    return xml_pretty, identifier.text, (update_date or creation_date)[:10]
+
+
+
+def run_harvester_mdposit(run_info: dict) -> bool:
+
+    try:
+        record_count = 0
+        harvest_events = 0
+        failed_events = 0
+
+        config = run_info.get("endpoint_config")
+        harvest_url = config.get("harvest_url")
+
+        mdposit_data_projects = fetch_projects_data(harvest_url)
+        for project in mdposit_data_projects:
+            mdposit_xml, identifier, datestamp = mdposit_data_to_datacite(project)
+
+            event_payload = {
+                "record_identifier": identifier,
+                "datestamp": datestamp,
+                "raw_metadata": mdposit_xml,
+                "additional_metadata": None,
+                "harvest_url": "https://mdposit.mddbr.eu/api/rest/v1",
+                "repo_code": "MDDB",
+                "harvest_run_id": run_info.get("id"),
+                "is_deleted": False
+            }
+
+            if send_harvest_event(event_payload):
+                harvest_events += 1
+            else:
+                failed_events += 1
+
+        logger.info(
+            "Harvest summary: processed %s records, successfully sent %s of them to the warehouse, failed to send %s records.",
+            record_count,
+            harvest_events,
+            failed_events
+        )
+
+        if failed_events == 0:
+            return True
+        else:
+            return False
+            
+    except Exception as e:
+        logger.exception("Unexpected error in run_harvester_oaipmh: %s", e)
+        logger.info(
+            "Harvest summary: processed %s records, successfully sent %s of them to the warehouse, failed to send %s records.",
+            record_count,
+            harvest_events,
+            failed_events
+        )
+        return False

--- a/harvester/harvester_mdposit.py
+++ b/harvester/harvester_mdposit.py
@@ -1,4 +1,5 @@
 import logging, os, requests, xml.etree.ElementTree as ET, time, mimetypes
+from datetime import datetime
 from .db_api_functions import send_harvest_event
 from xml.dom import minidom
 
@@ -25,28 +26,26 @@ def guess_format(filename: str) -> str:
 
 
 
-def fetch_projects_summary() -> dict:
-    url = "https://mdposit.mddbr.eu/api/rest/v1/projects/summary"
-    headers = {"Accept": "application/json"}
+def fetch_projects_summary(base_api_url, headers) -> dict:
+    url = f"{base_api_url}/projects/summary"
     response = requests.get(url, headers = headers, timeout = 30)
     response.raise_for_status()
     return response.json()
 
 
 
-def fetch_projects_data(base_api_url: str) -> list:
+def fetch_projects_data(base_api_url: str, from_date, headers) -> list:
     """
     Fetch all projects from the MDposit API using pagination.
     """
-    project_summary = fetch_projects_summary()
+    project_summary = fetch_projects_summary(base_api_url, headers)
     total = project_summary["projectsCount"]
     print(f"Total projects: {total}")
 
-    all_projects = []
-    headers = {"Accept": "application/json"}
+    projects = []
     page = 1
 
-    while len(all_projects) < total:
+    while len(projects) < total:
         response = requests.get(
             f"{base_api_url}/projects",
             headers = headers,
@@ -55,12 +54,19 @@ def fetch_projects_data(base_api_url: str) -> list:
         )
         response.raise_for_status()
         data = response.json()
-        all_projects.extend(data["projects"])
-        print(f"Fetched page {page}, total so far: {len(all_projects)}")
+        projects.extend(data["projects"])
+        print(f"Fetched page {page}, total so far: {len(projects)}")
         page += 1
         time.sleep(1)
 
-    return all_projects
+    if from_date:
+        filtered_projects = [
+            p for p in projects
+            if p.get("creationDate") and datetime.fromisoformat(p["creationDate"].replace("Z", "+00:00")) > datetime.fromisoformat(from_date.replace("Z", "+00:00"))
+        ]
+        return filtered_projects
+    else:
+        return projects
 
 
 
@@ -170,6 +176,8 @@ def mdposit_data_to_datacite(project: dict):
     for ref in meta.get("REFERENCES") or []:
         ET.SubElement(related, "relatedIdentifier", relatedIdentifierType = "URL", relationType = "References").text = f"https://www.uniprot.org/uniprot/{ref}"
 
+    # {"metadata.GROUPS":{"$regex":"IRB Barcelona"}}
+
     # DOI from citation
     citation = meta.get("CITATION") or ""
     if citation:
@@ -212,8 +220,10 @@ def run_harvester_mdposit(run_info: dict) -> bool:
 
         config = run_info.get("endpoint_config")
         harvest_url = config.get("harvest_url")
+        from_date = run_info.get("from_date")
+        headers = {"Accept": "application/json"}
 
-        mdposit_data_projects = fetch_projects_data(harvest_url)
+        mdposit_data_projects = fetch_projects_data(harvest_url, from_date, headers)
         for project in mdposit_data_projects:
             mdposit_xml, identifier, datestamp = mdposit_data_to_datacite(project)
 
@@ -222,7 +232,7 @@ def run_harvester_mdposit(run_info: dict) -> bool:
                 "datestamp": datestamp,
                 "raw_metadata": mdposit_xml,
                 "additional_metadata": None,
-                "harvest_url": "https://mdposit.mddbr.eu/api/rest/v1",
+                "harvest_url": harvest_url,
                 "repo_code": "MDDB",
                 "harvest_run_id": run_info.get("id"),
                 "is_deleted": False

--- a/harvester/harvester_mdposit.py
+++ b/harvester/harvester_mdposit.py
@@ -249,12 +249,13 @@ def run_harvester_mdposit(run_info: dict) -> bool:
         mdposit_data_projects = fetch_projects_data(harvest_url, from_date, headers)
         for project in mdposit_data_projects:
             mdposit_xml, identifier, datestamp = mdposit_data_to_datacite(project)
+            additional_file_metadata = ", ".join(project.get("files", []))
 
             event_payload = {
                 "record_identifier": identifier,
                 "datestamp": datestamp,
                 "raw_metadata": mdposit_xml,
-                "additional_metadata": None,
+                "additional_metadata": additional_file_metadata,
                 "harvest_url": harvest_url,
                 "repo_code": "MDDB",
                 "harvest_run_id": run_info.get("id"),

--- a/harvester/harvester_mdposit.py
+++ b/harvester/harvester_mdposit.py
@@ -45,7 +45,7 @@ def fetch_projects_data(base_api_url: str, from_date, headers) -> list:
     projects = []
     page = 1
 
-    while len(projects) < total:
+    while len(projects) < 100:
         response = requests.get(
             f"{base_api_url}/projects",
             headers = headers,
@@ -67,6 +67,40 @@ def fetch_projects_data(base_api_url: str, from_date, headers) -> list:
         return filtered_projects
     else:
         return projects
+
+
+
+def build_description(project) -> str:
+    meta = project["metadata"]
+    sentences = []
+
+    # METHOD
+    method = meta.get("METHOD")
+    if method:
+        sentences.append(f"The dataset was generated using {method}.")
+
+    # SYSKEYS
+    syskeys = meta.get("SYSKEYS") or []
+    if syskeys:
+        sentences.append(f"he system is composed of the following components: {', '.join(syskeys)}.")
+
+    # DOMAINS
+    domains = meta.get("DOMAINS") or []
+    if domains:
+        clean_domains = ", ".join(domains)
+        sentences.append(
+            f"The system relates to the following domains: {clean_domains}."
+        )
+
+    # ANALYSES
+    analyses = project.get("analyses") or []
+    if analyses:
+        pretty = ", ".join(analyses)
+        sentences.append(
+            f"The dataset includes the following analyses: {pretty}."
+        )
+
+    return " ".join(sentences)
 
 
 
@@ -141,17 +175,6 @@ def mdposit_data_to_datacite(project: dict):
     # RESOURCE TYPE
     ET.SubElement(resource, "resourceType", resourceTypeGeneral="Dataset").text = "Molecular Dynamics Trajectory"
 
-    # SUBJECTS
-    subjects = ET.SubElement(resource, "subjects")
-    for key in meta.get("SYSKEYS") or []:
-        ET.SubElement(subjects, "subject").text = key
-
-    for domain in meta.get("DOMAINS") or []:
-        ET.SubElement(subjects, "subject").text = domain
-
-    if meta.get("METHOD"):
-        ET.SubElement(subjects, "subject").text = meta.get("METHOD")
-
     # CONTRIBUTORS
     if meta.get("CONTACT"):
         contributors = ET.SubElement(resource, "contributors")
@@ -168,17 +191,15 @@ def mdposit_data_to_datacite(project: dict):
 
     # RELATED IDENTIFIERS
     related = ET.SubElement(resource, "relatedIdentifiers")
-    # PDB IDs
+    # PDB
     for pdbid in meta.get("PDBIDS") or []:
         ET.SubElement(related, "relatedIdentifier", relatedIdentifierType = "URL", relationType = "IsDerivedFrom").text = f"https://www.rcsb.org/structure/{pdbid}"
 
-    # UniProt references
+    # UniProt
     for ref in meta.get("REFERENCES") or []:
         ET.SubElement(related, "relatedIdentifier", relatedIdentifierType = "URL", relationType = "References").text = f"https://www.uniprot.org/uniprot/{ref}"
 
-    # {"metadata.GROUPS":{"$regex":"IRB Barcelona"}}
-
-    # DOI from citation
+    # DOI
     citation = meta.get("CITATION") or ""
     if citation:
         if "https://doi.org/" in citation:
@@ -202,8 +223,10 @@ def mdposit_data_to_datacite(project: dict):
 
     # DESCRIPTIONS
     descriptions = ET.SubElement(resource, "descriptions")
+    description_text = build_description(project)
     if meta.get("DESCRIPTION"):
-        ET.SubElement(descriptions, "description", descriptionType = "Abstract").text = meta["DESCRIPTION"]
+        description_text = meta["DESCRIPTION"].strip() + " " + description_text
+    ET.SubElement(descriptions, "description", descriptionType="Abstract").text = description_text
 
     xml_str = ET.tostring(record, encoding="unicode")
     xml_pretty = minidom.parseString(xml_str).toprettyxml(indent="  ")

--- a/harvester/harvester_mdposit.py
+++ b/harvester/harvester_mdposit.py
@@ -109,7 +109,7 @@ def fetch_all_projects_data(base_api_url: str, headers: dict[str, str]) -> list:
 
 
 
-def fetch_incremental_projects_data(base_api_url: str, from_date, headers: dict[str, str]) -> list:
+def fetch_incremental_projects_data(base_api_url: str, from_date: str, headers: dict[str, str]) -> list:
     """
     Retrieve projects updated after a specified date.
 
@@ -216,7 +216,7 @@ def build_description(project: dict) -> str:
 
 
 
-def mdposit_data_to_datacite(project: dict):
+def mdposit_data_to_datacite(project: dict) -> tuple[str, str, str]:
     """
     Convert an MDposit project record into a DataCite XML record.
 
@@ -291,12 +291,6 @@ def mdposit_data_to_datacite(project: dict):
     # TITLES
     titles = ET.SubElement(resource, "titles")
     ET.SubElement(titles, "title").text = meta.get("NAME", "")
-
-    # PUBLISHER
-    # ET.SubElement(resource, "publisher").text = "MDposit"
-
-    # PUBLICATION YEAR
-    # ET.SubElement(resource, "publicationYear").text = creation_date[:4]
 
     # RESOURCE TYPE
     ET.SubElement(resource, "resourceType", resourceTypeGeneral="Dataset").text = "Molecular Dynamics Simulations"

--- a/harvester/harvester_mdposit.py
+++ b/harvester/harvester_mdposit.py
@@ -1,4 +1,4 @@
-import logging, os, requests, xml.etree.ElementTree as ET, time, mimetypes
+import logging, os, requests, xml.etree.ElementTree as ET, time, mimetypes, json
 from datetime import datetime
 from .db_api_functions import send_harvest_event
 from xml.dom import minidom
@@ -9,9 +9,25 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def guess_format(filename: str) -> str:
+    """
+    Determine the MIME type of a file based on its filename extension.
+
+    Uses Python's built-in mimetype detection and provides custom
+    fallbacks for scientific file formats that are not recognized
+    by the standard library.
+
+    Args:
+        filename: Name of the file whose MIME type should be determined.
+
+    Returns:
+        A MIME type string (e.g. "application/json",
+        "chemical/x-pdb", "application/octet-stream").
+
+    Notes:
+        Unknown file types default to "application/octet-stream".
+    """
     mime, _ = mimetypes.guess_type(filename)
 
-    # fallback for unknown scientific formats
     if mime is None:
         ext = filename.lower().split(".")[-1]
         custom_map = {
@@ -27,6 +43,20 @@ def guess_format(filename: str) -> str:
 
 
 def fetch_projects_summary(base_api_url, headers) -> dict:
+    """
+    Retrieve project summary statistics from the MDposit API.
+
+    This endpoint is used to obtain metadata about the repository,
+    including the total number of available projects.
+
+    Args:
+        base_api_url: Base URL of the MDposit API.
+        headers: HTTP headers to include in the request.
+
+    Returns:
+        Dictionary containing summary information returned by
+        the API.
+    """
     url = f"{base_api_url}/projects/summary"
     response = requests.get(url, headers = headers, timeout = 30)
     response.raise_for_status()
@@ -34,9 +64,23 @@ def fetch_projects_summary(base_api_url, headers) -> dict:
 
 
 
-def fetch_projects_data(base_api_url: str, from_date, headers) -> list:
+def fetch_all_projects_data(base_api_url: str, headers) -> list:
     """
-    Fetch all projects from the MDposit API using pagination.
+    Retrieve all projects from the MDposit API.
+
+    Projects are fetched in batches using paginated requests until
+    all available records have been collected.
+
+    Args:
+        base_api_url: Base URL of the MDposit API.
+        headers: HTTP headers to include in API requests.
+
+    Returns:
+        List of project dictionaries returned by the API.
+
+    Notes:
+        A one-second delay is applied between requests to avoid
+        overwhelming the API.
     """
     project_summary = fetch_projects_summary(base_api_url, headers)
     total = project_summary["projectsCount"]
@@ -59,18 +103,82 @@ def fetch_projects_data(base_api_url: str, from_date, headers) -> list:
         page += 1
         time.sleep(1)
 
-    if from_date:
-        filtered_projects = [
-            p for p in projects
-            if p.get("creationDate") and datetime.fromisoformat(p["creationDate"].replace("Z", "+00:00")) > datetime.fromisoformat(from_date.replace("Z", "+00:00"))
-        ]
-        return filtered_projects
-    else:
-        return projects
+    return projects
+
+
+
+def fetch_incremental_projects_data(base_api_url: str, from_date, headers) -> list:
+    """
+    Retrieve projects updated after a specified date.
+
+    Performs an incremental harvest by requesting only projects
+    whose update date is greater than the supplied timestamp.
+
+    The method first determines the total number of matching
+        projects and then retrieves them using paginated requests.
+
+    Args:
+        base_api_url: Base URL of the MDposit API.
+        from_date: ISO-formatted date used as the lower bound for project updates.
+        headers: HTTP headers to include in API requests.
+
+    Returns:
+        List of project dictionaries updated after the specified date.
+
+    Notes:
+        A one-second delay is applied between requests to avoid
+        overwhelming the API.
+    """
+    
+    query = {"updateDate": {"$gt": from_date}}
+    
+    # inital request just to see how many filtered projects there are
+    response = requests.get(
+        f"{base_api_url}/projects",
+        headers = headers,
+        params = {"limit": 0, "page": 1, "query": json.dumps(query)},
+        timeout = 30
+    )
+
+    response.raise_for_status()
+    data = response.json()
+    number_of_filtered_objects = data["filteredCount"]
+
+    # fetching all filtered projects 
+    projects = []
+    page = 1
+    while len(projects) < number_of_filtered_objects:
+        response = requests.get(
+            f"{base_api_url}/projects",
+            headers = headers,
+            params = {"limit": 100, "page": page, "query": json.dumps(query)},
+            timeout = 30
+        )
+        response.raise_for_status()
+        data = response.json()
+        projects.extend(data["projects"])
+        print(f"Fetched page {page}, total so far: {len(projects)}")
+        page += 1
+        time.sleep(1)
+    return projects
 
 
 
 def build_description(project) -> str:
+    """
+    Generate a human-readable dataset description from project metadata.
+
+    Constructs descriptive sentences using selected metadata fields
+    such as simulation method, system components, domains, and
+    available analyses.
+
+    Args:
+        project: Project dictionary returned by the MDposit API.
+
+    Returns:
+        A textual description suitable for inclusion in metadata
+        records and discovery systems.
+    """
     meta = project["metadata"]
     sentences = []
 
@@ -105,6 +213,20 @@ def build_description(project) -> str:
 
 
 def mdposit_data_to_datacite(project: dict):
+    """
+    Convert an MDposit project record into a DataCite XML record.
+
+    Args:
+        project: Project dictionary obtained from the MDposit API.
+
+    Returns:
+        A tuple containing:
+            - xml_pretty (str): Formatted DataCite XML record.
+            - identifier (str): Dataset URL identifier.
+            - datestamp (str): Record update or creation date
+              in YYYY-MM-DD format.
+    """
+
     meta = project["metadata"]
 
     # NAMESPACES
@@ -223,7 +345,6 @@ def mdposit_data_to_datacite(project: dict):
 
     # DESCRIPTIONS
     descriptions = ET.SubElement(resource, "descriptions")
-    # description_text = build_description(project)
     if meta.get("DESCRIPTION"):
         description_text = meta["DESCRIPTION"].strip()
     description_text = build_description(project) + " " + description_text
@@ -236,6 +357,26 @@ def mdposit_data_to_datacite(project: dict):
 
 
 def run_harvester_mdposit(run_info: dict) -> bool:
+    """
+    Depending on the supplied configuration, performs either a full
+    harvest or an incremental harvest, converts each project into
+    DataCite XML, and publishes harvest events to the data warehouse.
+
+    Args:
+        run_info: Harvest execution configuration containing:
+            - endpoint_config.harvest_url
+            - from_date (optional)
+            - id (harvest run identifier)
+
+    Returns:
+        True if all harvest events were successfully sent;
+        False if any failures occurred or an unexpected error
+        was encountered.
+
+    Raises:
+        No exceptions are propagated. Unexpected errors are logged
+        and result in a False return value.
+    """
 
     try:
         record_count = 0
@@ -247,7 +388,10 @@ def run_harvester_mdposit(run_info: dict) -> bool:
         from_date = run_info.get("from_date")
         headers = {"Accept": "application/json"}
 
-        mdposit_data_projects = fetch_projects_data(harvest_url, from_date, headers)
+        if not from_date:
+            mdposit_data_projects = fetch_all_projects_data(harvest_url, headers)
+        else:
+            mdposit_data_projects = fetch_incremental_projects_data(harvest_url, from_date, headers)
         for project in mdposit_data_projects:
             mdposit_xml, identifier, datestamp = mdposit_data_to_datacite(project)
             additional_file_metadata = ", ".join(project.get("files", []))

--- a/harvester/harvester_mdposit.py
+++ b/harvester/harvester_mdposit.py
@@ -347,7 +347,9 @@ def mdposit_data_to_datacite(project: dict):
     descriptions = ET.SubElement(resource, "descriptions")
     if meta.get("DESCRIPTION"):
         description_text = meta["DESCRIPTION"].strip()
-    description_text = build_description(project) + " " + description_text
+        description_text = build_description(project) + " " + description_text
+    else:
+        description_text = build_description(project)
     ET.SubElement(descriptions, "description", descriptionType="Abstract").text = description_text
 
     xml_str = ET.tostring(record, encoding="unicode")

--- a/harvester/harvester_mdposit.py
+++ b/harvester/harvester_mdposit.py
@@ -89,7 +89,7 @@ def fetch_all_projects_data(base_api_url: str, headers) -> list:
     projects = []
     page = 1
 
-    while len(projects) < 100:
+    while len(projects) < total:
         response = requests.get(
             f"{base_api_url}/projects",
             headers = headers,

--- a/harvester/harvester_mdposit.py
+++ b/harvester/harvester_mdposit.py
@@ -2,6 +2,7 @@ import logging, os, requests, xml.etree.ElementTree as ET, time, mimetypes, json
 from datetime import datetime
 from .db_api_functions import send_harvest_event
 from xml.dom import minidom
+from typing import Any, cast
 
 logger = logging.getLogger(__name__)
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -42,7 +43,7 @@ def guess_format(filename: str) -> str:
 
 
 
-def fetch_projects_summary(base_api_url, headers) -> dict:
+def fetch_projects_summary(base_api_url: str, headers: dict[str, str]) -> dict[str, Any]:
     """
     Retrieve project summary statistics from the MDposit API.
 
@@ -60,11 +61,12 @@ def fetch_projects_summary(base_api_url, headers) -> dict:
     url = f"{base_api_url}/projects/summary"
     response = requests.get(url, headers = headers, timeout = 30)
     response.raise_for_status()
-    return response.json()
+    summary = response.json() 
+    return cast(dict[str, Any], summary)
 
 
 
-def fetch_all_projects_data(base_api_url: str, headers) -> list:
+def fetch_all_projects_data(base_api_url: str, headers: dict[str, str]) -> list:
     """
     Retrieve all projects from the MDposit API.
 
@@ -86,7 +88,7 @@ def fetch_all_projects_data(base_api_url: str, headers) -> list:
     total = project_summary["projectsCount"]
     print(f"Total projects: {total}")
 
-    projects = []
+    projects : list[dict] = []
     page = 1
 
     while len(projects) < total:
@@ -107,7 +109,7 @@ def fetch_all_projects_data(base_api_url: str, headers) -> list:
 
 
 
-def fetch_incremental_projects_data(base_api_url: str, from_date, headers) -> list:
+def fetch_incremental_projects_data(base_api_url: str, from_date, headers: dict[str, str]) -> list:
     """
     Retrieve projects updated after a specified date.
 
@@ -131,12 +133,13 @@ def fetch_incremental_projects_data(base_api_url: str, from_date, headers) -> li
     """
     
     query = {"updateDate": {"$gt": from_date}}
+    params : dict[str, str | int] = {"limit": 0, "page": 1, "query": json.dumps(query)}
     
     # inital request just to see how many filtered projects there are
     response = requests.get(
         f"{base_api_url}/projects",
         headers = headers,
-        params = {"limit": 0, "page": 1, "query": json.dumps(query)},
+        params = params,
         timeout = 30
     )
 
@@ -145,13 +148,14 @@ def fetch_incremental_projects_data(base_api_url: str, from_date, headers) -> li
     number_of_filtered_objects = data["filteredCount"]
 
     # fetching all filtered projects 
-    projects = []
+    projects : list[dict] = []
     page = 1
+    params_filtered : dict[str, str | int] = {"limit": 100, "page": page, "query": json.dumps(query)}
     while len(projects) < number_of_filtered_objects:
         response = requests.get(
             f"{base_api_url}/projects",
             headers = headers,
-            params = {"limit": 100, "page": page, "query": json.dumps(query)},
+            params = params_filtered,
             timeout = 30
         )
         response.raise_for_status()
@@ -380,12 +384,14 @@ def run_harvester_mdposit(run_info: dict) -> bool:
         and result in a False return value.
     """
 
+    record_count = 0
+    harvest_events = 0
+    failed_events = 0
     try:
-        record_count = 0
-        harvest_events = 0
-        failed_events = 0
 
         config = run_info.get("endpoint_config")
+        if config is None:
+            raise ValueError("config is missing")
         harvest_url = config.get("harvest_url")
         from_date = run_info.get("from_date")
         headers = {"Accept": "application/json"}

--- a/harvester/harvester_mdposit.py
+++ b/harvester/harvester_mdposit.py
@@ -82,7 +82,7 @@ def build_description(project) -> str:
     # SYSKEYS
     syskeys = meta.get("SYSKEYS") or []
     if syskeys:
-        sentences.append(f"he system is composed of the following components: {', '.join(syskeys)}.")
+        sentences.append(f"The system is composed of the following components: {', '.join(syskeys)}.")
 
     # DOMAINS
     domains = meta.get("DOMAINS") or []
@@ -167,13 +167,13 @@ def mdposit_data_to_datacite(project: dict):
     ET.SubElement(titles, "title").text = meta.get("NAME", "")
 
     # PUBLISHER
-    ET.SubElement(resource, "publisher").text = "MDposit"
+    # ET.SubElement(resource, "publisher").text = "MDposit"
 
     # PUBLICATION YEAR
-    ET.SubElement(resource, "publicationYear").text = creation_date[:4]
+    # ET.SubElement(resource, "publicationYear").text = creation_date[:4]
 
     # RESOURCE TYPE
-    ET.SubElement(resource, "resourceType", resourceTypeGeneral="Dataset").text = "Molecular Dynamics Trajectory"
+    ET.SubElement(resource, "resourceType", resourceTypeGeneral="Dataset").text = "Molecular Dynamics Simulations"
 
     # CONTRIBUTORS
     if meta.get("CONTACT"):
@@ -223,9 +223,10 @@ def mdposit_data_to_datacite(project: dict):
 
     # DESCRIPTIONS
     descriptions = ET.SubElement(resource, "descriptions")
-    description_text = build_description(project)
+    # description_text = build_description(project)
     if meta.get("DESCRIPTION"):
-        description_text = meta["DESCRIPTION"].strip() + " " + description_text
+        description_text = meta["DESCRIPTION"].strip()
+    description_text = build_description(project) + " " + description_text
     ET.SubElement(descriptions, "description", descriptionType="Abstract").text = description_text
 
     xml_str = ET.tostring(record, encoding="unicode")

--- a/harvester/harvester_mdposit.py
+++ b/harvester/harvester_mdposit.py
@@ -168,7 +168,7 @@ def fetch_incremental_projects_data(base_api_url: str, from_date, headers: dict[
 
 
 
-def build_description(project) -> str:
+def build_description(project: dict) -> str:
     """
     Generate a human-readable dataset description from project metadata.
 

--- a/harvester/main.py
+++ b/harvester/main.py
@@ -1,9 +1,10 @@
-import argparse
+import argparse, sys
 import logging
 from datetime import datetime, timezone
 
 from .harvester_oaipmh import run_harvester_oaipmh, close_dataverse_client
 from harvester.harvester_finbif import run_harvester_finbif
+from harvester.harvester_mdposit import run_harvester_mdposit
 from .db_api_functions import start_harvest_run, close_harvest_run, get_open_run_id, close_warehouse_client
 from .logging import setup_logging
 
@@ -61,6 +62,8 @@ def main():
             harvest_success = run_harvester_oaipmh(run_info)
         elif harvesting_protocol == "FINBIF_API":
             harvest_success = run_harvester_finbif(run_info)
+        elif harvesting_protocol == "MDPOSIT_API":
+            harvest_success = run_harvester_mdposit(run_info)
         else:
             raise ValueError(f"Unsupported protocol: {harvesting_protocol}")
 


### PR DESCRIPTION
In this PR, a new script harvester_mdposit.py has been implemented to harvest metadata from the MDDB repository API. The script transforms their JSON metadata into the DataCite 4.6 schema. The API contains approximately 8k “projects”, and each project is currently mapped to a single dataset. Full harvesting of all project metadata is working correctly. However, incremental harvesting still needs to be tested and validated. Each project includes a metadata file, and there is potential to extend the harvester to collect additional metadata. The API also supports file downloads. Most projects already contain the core metadata elements required by the DataCite 4.6 schema, such as title, authors, publication date, identifier, etc.

Issues / limitations:
- some projects do not have a DOI assigned
- the description field is often not very informative or lacks detail
- it would be beneficial to populate subject with more meaningful keywords, but it is currently unclear how to reliably extract or define what is most relevant

TODO:
- make method for file metadata for additional_metadata column