### PR TITLE
feat(finbif): enrich datasets with aggregate taxon data from laji.fi

### DIFF
--- a/harvester/harvester_finbif.py
+++ b/harvester/harvester_finbif.py
@@ -72,10 +72,38 @@ async def shutdown_async_client():
         logger.error("Error closing async client: %s", e)
 
 
-def build_datacite_xml(record: dict) -> str:
+async def fetch_aggregate_taxon_data(collection_id: str) -> dict:
+    """
+    Fetch aggregate taxon data from laji.fi for enrichment.
+    Returns aggregate results with taxon names and counts.
+    """
+    url = "https://laji.fi/api/warehouse/query/unit/aggregate"
+    params = {
+        "collectionId": collection_id,
+        "aggregateBy": "unit.linkings.taxon.scientificName",
+        "pageSize": 10000,
+        "onlyCount": "false",
+    }
+    
+    try:
+        # Create a direct async client for this request (not using the shared client)
+        async with httpx.AsyncClient(timeout=httpx.Timeout(120)) as client:
+            response = await client.get(url, params=params)
+            response.raise_for_status()
+            data = response.json()
+            logger.debug("Fetched aggregate data for %s: %d taxa", collection_id, len(data.get("results", [])))
+            return data
+    except Exception as e:
+        logger.warning("Failed to fetch aggregate data for %s: %s", collection_id, e)
+        return {"results": []}
+
+def build_datacite_xml(record: dict, aggregate_data: dict = None) -> str:
     dataset = record["dataset"]
     additional = record["additional"]
     dataset_id = record["id"]
+    
+    if aggregate_data is None:
+        aggregate_data = {"results": []}
 
     # OAI-PMH wrapper
     root = etree.Element(
@@ -135,6 +163,18 @@ def build_datacite_xml(record: dict) -> str:
         etree.SubElement(subjects_el, "subject",
                          attrib={f"{{{XML_NS}}}lang": lang},
                          ).text = text
+
+    # taxon data from finbif API (aggregateBy)
+    for item in aggregate_data.get("results", []):
+        if item.get("count", 0) < 2:
+            continue  # Skip taxa with less than 2 occurrences to prevent XML bloat too much
+        agg = item.get("aggregateBy", {})
+        sci_name = agg.get("unit.linkings.taxon.scientificName")
+        
+        # Add scientific name (Latin)
+        if sci_name:
+            sci_el = etree.SubElement(subjects_el, "subject")
+            sci_el.text = sci_name
 
     # contributors
     if dataset["contacts"]:
@@ -286,8 +326,12 @@ async def harvest_finbif(run_info: dict) -> bool:
     for record in combined:
         record_counter += 1
         record_identifier = record["dataset"]["doi"]
+        dataset_id = record["id"]
 
-        datacite_xml = build_datacite_xml(record)
+        # Fetch aggregate taxon data for enrichment
+        aggregate_data = await fetch_aggregate_taxon_data(dataset_id.replace("http://tun.fi/", ""))
+
+        datacite_xml = build_datacite_xml(record, aggregate_data)
 
         try:
             event_payload = {

--- a/harvester/harvester_finbif.py
+++ b/harvester/harvester_finbif.py
@@ -18,6 +18,7 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 # Base URL and config for the FinBIF API
 API_BASE = "https://api.gbif.org"
 API_ADDITIONAL = "https://tun.fi"
+LAJI_FI_API = "https://laji.fi/api/warehouse/query/unit/aggregate"
 KEY = "b1304814-56cc-434e-8d40-2b24fa21526f"
 
 OAI_NS = "http://www.openarchives.org/OAI/2.0/"
@@ -72,38 +73,36 @@ async def shutdown_async_client():
         logger.error("Error closing async client: %s", e)
 
 
-async def fetch_aggregate_taxon_data(collection_id: str) -> dict:
+async def fetch_aggregate_taxon_data(collection_id: str) -> list:
     """
     Fetch aggregate taxon data from laji.fi for enrichment.
     Returns aggregate results with taxon names and counts.
     """
-    url = "https://laji.fi/api/warehouse/query/unit/aggregate"
     params = {
         "collectionId": collection_id,
         "aggregateBy": "unit.linkings.taxon.scientificName",
-        "pageSize": 10000,
+        "pageSize": 10,
         "onlyCount": "false",
-    }
+    } # Returns top 10 scientific names based on occurrence counts in the collection
     
     try:
-        # Create a direct async client for this request (not using the shared client)
-        async with httpx.AsyncClient(timeout=httpx.Timeout(120)) as client:
-            response = await client.get(url, params=params)
-            response.raise_for_status()
-            data = response.json()
-            logger.debug("Fetched aggregate data for %s: %d taxa", collection_id, len(data.get("results", [])))
-            return data
+        response = await _ASYNC_FINBIF_CLIENT.get(LAJI_FI_API, params=params)
+        response.raise_for_status()
+        data = response.json()
+        results = data.get("results", [])
+        logger.debug("Fetched aggregate data for %s: %d taxa", collection_id, len(results))
+        return results
     except Exception as e:
         logger.warning("Failed to fetch aggregate data for %s: %s", collection_id, e)
-        return {"results": []}
+        return []
 
-def build_datacite_xml(record: dict, aggregate_data: dict = None) -> str:
+def build_datacite_xml(record: dict, aggregate_data: list = None) -> str:
     dataset = record["dataset"]
     additional = record["additional"]
     dataset_id = record["id"]
     
     if aggregate_data is None:
-        aggregate_data = {"results": []}
+        aggregate_data = []
 
     # OAI-PMH wrapper
     root = etree.Element(
@@ -165,9 +164,7 @@ def build_datacite_xml(record: dict, aggregate_data: dict = None) -> str:
                          ).text = text
 
     # taxon data from finbif API (aggregateBy)
-    for item in aggregate_data.get("results", []):
-        if item.get("count", 0) < 2:
-            continue  # Skip taxa with less than 2 occurrences to prevent XML bloat too much
+    for item in aggregate_data:
         agg = item.get("aggregateBy", {})
         sci_name = agg.get("unit.linkings.taxon.scientificName")
         
@@ -319,17 +316,13 @@ async def harvest_finbif(run_info: dict) -> bool:
         logger.error(f"Unexpected error while harvesting datasets: {e}")
         return False
 
-    finally:
-        shutdown_client()
-        await shutdown_async_client()
-
     for record in combined:
         record_counter += 1
         record_identifier = record["dataset"]["doi"]
         dataset_id = record["id"]
 
         # Fetch aggregate taxon data for enrichment
-        aggregate_data = await fetch_aggregate_taxon_data(dataset_id.replace("http://tun.fi/", ""))
+        aggregate_data = await fetch_aggregate_taxon_data(dataset_id.replace(f"{API_ADDITIONAL}/", ""))
 
         datacite_xml = build_datacite_xml(record, aggregate_data)
 
@@ -360,6 +353,9 @@ async def harvest_finbif(run_info: dict) -> bool:
         harvest_events,
         failed_events
     )
+
+    shutdown_client()
+    await shutdown_async_client()
 
     return success
 


### PR DESCRIPTION
As datasets were not findable using scientific names as search terms, I modified the script to include scientific names as object entries. Now the script queries aggregated scientific names per collection from api.laji.fi and adds them to XMLs. 