### PR TITLE
fix (harvester_oaipmh): catch NoRecordsMatch error

### DIFF
--- a/harvester/harvester_oaipmh.py
+++ b/harvester/harvester_oaipmh.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable, Iterator
 from typing import Any
 
 from oaipmh_scythe.models import Record
+from oaipmh_scythe.exceptions import NoRecordsMatch
 
 from .additional_metadata_functions import fetch_dataverse_json, fetch_additional_oai, fetch_additional_metadata_hal, \
     fetch_additional_metadata_zenodo
@@ -254,7 +255,15 @@ def fetch_records_by_sets(client: Scythe, sets: Iterable[str | None], from_: str
                 set_ = set_name, 
                 ignore_deleted = True
             )
-        yield from records
+
+        try:
+            yield from records
+        except NoRecordsMatch:
+            logger.info(
+                "No new records for set %s (from=%s, until=%s) — nothing to harvest.",
+                set_name, from_, until_
+            )
+            continue
 
 
 


### PR DESCRIPTION
NoRecordsMatch is raised lazily by oaipmh_scythe when list_records() is iterated and the from/until/set/metadataPrefix combination matches zero records (e.g. an incremental harvest with no new records https://demo.onedata.org/oai_pmh?verb=ListRecords&metadataPrefix=oai_datacite&from=2026-06-16T00:00:00Z&until=2026-07-31T00:00:00Z&set=a93d0c2877c38910bd10bc458e266debch24b6). This is a normal, expected outcome per the OAI-PMH spec, not a harvest failure, so we catch it per set, log it, and move on to the next set instead of letting it propagate up and get treated as an unexpected error (which was previously causing runs with no new records to be marked "failed" instead of "closed").